### PR TITLE
making the local branch names more specific

### DIFF
--- a/src/tasks/checkout.js
+++ b/src/tasks/checkout.js
@@ -34,7 +34,7 @@ function checkout(cmd) {
   }
 
   const [, remote, branch] = matches;
-  const branchName = `${remote}#${branch}`;
+  const branchName = `${remote}-${branch}`;
   addRemote(remote);
 
   info(`:running: fetching ${remote}...`);

--- a/src/tasks/checkout.js
+++ b/src/tasks/checkout.js
@@ -34,19 +34,23 @@ function checkout(cmd) {
   }
 
   const [, remote, branch] = matches;
+  const branchName = `${remote}#${branch}`;
   addRemote(remote);
 
   info(`:running: fetching ${remote}...`);
   gitCmd(`fetch ${remote}`);
   action(`:dizzy: successfully fetched ${remote}`);
 
-  info(`:running: checking out ${remote}/${branch}...`);
-  const { stderr, code } = gitCmd(`checkout --track ${remote}/${branch}`);
+  info(`:running: checking out ${remote}/${branch} to ${branchName}...`);
+  const { stderr, code } = gitCmd(
+    `checkout --track -b ${branchName} ${remote}/${branch}`
+  );
   if (code != 0) {
     error(`:bomb: ${stderr}`);
+  } else {
+    action(`:dizzy: checkout complete`);
+    action(`:dancer: Current branch: ${branchName}`);
   }
-
-  action(`:dancer: Current branch: ${branch}`);
 }
 
 module.exports = { checkout, parseCheckout };


### PR DESCRIPTION
Lets make the local branches more specific
ie
`foo co @baa:foo` creates a local branch `baa#foo` rather than `foo`

This fixes the issue where a remote branch like `baa:master` which would try to create  a local `master`. Instead we should have `baa#master`.

Open to changing the naming format, if there is a good reason to